### PR TITLE
Added dockerfile for production use.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM mhart/alpine-node:4.3.1
+WORKDIR /src
+ADD . .
+RUN npm install
+EXPOSE 5000
+CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
This PR adds a simple Dockerfile as request in the issue #9. It is based on [alpine-node](https://hub.docker.com/r/mhart/alpine-node/) and therefore on [alpine linux](https://hub.docker.com/r/mhart/alpine-node/), which decreases the image file sizes significantly. The official docker distributions [will eventually be switched](https://news.ycombinator.com/item?id=10998667) to alpine (see comment by shykes).

It currently runs the production environment but we might wan't to add a second Dockerfile to run this starterkit in development mode with the code mounted as volume, so devs can change code on the fly.