### PR TITLE
Fix item links on the about page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Isomorphic React Starter with Redux, React Router, Redial, CSS Modules, Express, Webpack.",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test ./node_modules/mocha/bin/mocha --compilers js:babel-core/register --recursive",
+    "test": "npm run build && NODE_ENV=test ./node_modules/mocha/bin/mocha --compilers js:babel-core/register --recursive",
     "test:watch": "npm test -- --watch",
     "start": "NODE_ENV=development node ./src/server",
     "start:prod": "npm run build && NODE_ENV=production node ./src/server",

--- a/src/routes/About/components/About.js
+++ b/src/routes/About/components/About.js
@@ -21,7 +21,7 @@ const About = (props) => {
       <h2 className={css(styles.header)}>Under the Hood</h2>
       <ul className={css(styles.list)}>
         { data.map((item, i) => <li>
-          <h3><a className={css(styles.link)} href="{item.link}" target="_blank">{item.resource}</a></h3>
+          <h3><a className={css(styles.link)} href={item.link} target="_blank">{item.resource}</a></h3>
           <p className={css(styles.body)}>{item.description}</p>
           </li>) }
       </ul>

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -83,9 +83,10 @@ if (isDeveloping) {
     log: console.log,
   }));
 } else {
+  const buildPath = require('../../webpack.config.prod').output.path;
   assets = require('../../assets.json');
   server.use(morgan('combined'));
-  server.use('/build/static', express.static(__dirname + '../../../build/static'));
+  server.use('/build/static', express.static(buildPath));
 }
 
 // Render Document (include global styles)


### PR DESCRIPTION
The links on the about page are broken, because the href uses `{item.link}` as string. This pull request fixes this issue.