### PR TITLE
Fix warning Warning: React attempted to reuse markup in a container b…

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -51,12 +51,12 @@ browserHistory.listen(location => {
 
     // Fetch deferred, client-only data dependencies:
     trigger('defer', components, locals);
+
+    // Render app with Redux and router context to container element:
+    render((
+      <Provider store={store}>
+          <Router history={browserHistory} routes={routes} />
+      </Provider>
+    ), container);
   });
 });
-
-// Render app with Redux and router context to container element:
-render((
-  <Provider store={store}>
-      <Router history={browserHistory} routes={routes} />
-  </Provider>
-), container);


### PR DESCRIPTION
This could fix the warning of 

`Warning: React attempted to reuse markup in a container but the checksum was invalid. This generally means that you are using server rendering and the markup generated on the server was not what the client was expecting. React injected new markup to compensate which works but you have lost many of the benefits of server rendering. Instead, figure out why the markup being generated is different on the client or server`

when directly visit post urls like [http://localhost:5000/post/the-pathway-to-more-success](url)