### PR TITLE
Fix checksum invalid warning

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -51,12 +51,12 @@ browserHistory.listen(location => {
 
     // Fetch deferred, client-only data dependencies:
     trigger('defer', components, locals);
+
+    // Render app with Redux and router context to container element:
+    render((
+      <Provider store={store}>
+          <Router history={browserHistory} routes={routes} />
+      </Provider>
+    ), container);
   });
 });
-
-// Render app with Redux and router context to container element:
-render((
-  <Provider store={store}>
-      <Router history={browserHistory} routes={routes} />
-  </Provider>
-), container);

--- a/src/client.js
+++ b/src/client.js
@@ -24,6 +24,16 @@ const routes = createRoutes(store);
 const container = document.getElementById('root');
 StyleSheet.rehydrate(window.renderedClassNames);
 
+// Pull child routes using match
+match({ routes, location }, () => {
+  // Render app with Redux and router context to container element:
+  render((
+    <Provider store={store}>
+        <Router history={browserHistory} routes={routes} />
+    </Provider>
+  ), container);
+});
+
 browserHistory.listen(location => {
   // Match routes based on location object:
   match({ routes, location }, (error, redirectLocation, renderProps) => {
@@ -51,12 +61,5 @@ browserHistory.listen(location => {
 
     // Fetch deferred, client-only data dependencies:
     trigger('defer', components, locals);
-
-    // Render app with Redux and router context to container element:
-    render((
-      <Provider store={store}>
-          <Router history={browserHistory} routes={routes} />
-      </Provider>
-    ), container);
   });
 });


### PR DESCRIPTION
This can eliminate the checksum warning received when directly visit child routes like [http://0.0.0.0:5000/post/hows-business-boomin](url)