### PR TITLE
Fix typo in webpack.optimize.OccurrenceOrderPlugin

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -27,7 +27,7 @@ module.exports = {
     publicPath: '/build/static/'
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js', 2),
     new webpack.NoErrorsPlugin(),


### PR DESCRIPTION
It's already fixed in `webpack.config.prod.js`. Fixes #50 