### PR TITLE
node-hooks solution

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react", "stage-0"]
+  "presets": ["es2015", "react", "stage-0"],
+  "plugins": ["transform-runtime"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["es2015", "react", "stage-0"],
-  "plugins": ["transform-react-constant-elements", "transform-react-inline-elements"]
+  "presets": ["es2015", "react", "stage-0"]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-loader": "^6.2.2",
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.5.0",
+    "babel-plugin-transform-runtime": "^6.9.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",

--- a/src/client.js
+++ b/src/client.js
@@ -1,12 +1,10 @@
-import 'babel-polyfill';
-import { trigger } from 'redial';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from 'react-router/lib/Router';
 import match from 'react-router/lib/match';
 import browserHistory from 'react-router/lib/browserHistory';
 import { Provider } from 'react-redux';
+import { trigger } from 'redial';
 import { StyleSheet } from 'aphrodite';
 
 import { configureStore } from './store';

--- a/src/routes/Post/index.js
+++ b/src/routes/Post/index.js
@@ -13,7 +13,7 @@ export default function createRoutes(store) {
           let postReducer = require('./reducer').default;
           injectAsyncReducer(store, 'currentPost', postReducer);
           cb(null, PostPage);
-        });
+        }, 'post_page');
     },
   };
 }

--- a/src/routes/root.js
+++ b/src/routes/root.js
@@ -17,7 +17,7 @@ export default function createRoutes(store) {
 
           require('./NotFound').default
         ]);
-      });
+      }, 'root');
     },
 
     indexRoute: {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,11 +1,3 @@
 require('babel-register');
-if (process.env.NODE_ENV != 'production') {
-  require.extensions['.png'] = function () {};
-  require.extensions['.jpg'] = function () {};
-  require.extensions['.jpeg'] = function () {};
-  require.extensions['.woff'] = function () {};
-  require.extensions['.woff2'] = function () {};
-  require.extensions['.ico'] = function () {};
-  require.extensions['.svg'] = function () {};
-}
+require('./node-hooks');
 require('./server');

--- a/src/server/node-hooks.js
+++ b/src/server/node-hooks.js
@@ -28,7 +28,7 @@ const requireHook = (context, filename) => {
   const content = fs.readFileSync(filename)
 
   // Note: filename template must match url/file loader configuration!
-  const filenameTemplate = '[name].[ext]?[hash]'
+  const filenameTemplate = '[name].[hash].[ext]'
 
   // Resolve using https://github.com/webpack/loader-utils
   const outputName = interpolateName(

--- a/src/server/node-hooks.js
+++ b/src/server/node-hooks.js
@@ -1,0 +1,49 @@
+import fs from 'fs'
+import { interpolateName } from 'loader-utils'
+import webpackConfig from '../../webpack.config.dev'
+
+// Helper for webpack loaders to properly resolve module
+// imports in node for server-side rendering
+
+// If you add a new extension below, remember to update
+// the related file/url loader configuration in webpack.config
+
+const extensions = [
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'ico',
+  'svg',
+  'otf',
+  'eot',
+  'svg',
+  'ttf',
+  'woff',
+  'woff2'
+]
+
+// Allows webpack's node runtime to resolve file/url imports
+const requireHook = (context, filename) => {
+  const content = fs.readFileSync(filename)
+
+  // Note: filename template must match url/file loader configuration!
+  const filenameTemplate = '[name].[ext]?[hash]'
+
+  // Resolve using https://github.com/webpack/loader-utils
+  const outputName = interpolateName(
+    { resourcePath: filename },
+    filenameTemplate,
+    { content }
+  )
+
+  // Export fully resolved path
+  context.exports = `${webpackConfig.output.publicPath}${outputName}`
+}
+
+extensions.forEach(hook => {
+  if (require.extensions[`.${hook}`])
+    return null
+
+  require.extensions[`.${hook}`] = requireHook
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -85,7 +85,7 @@ if (isDeveloping) {
 } else {
   assets = require('../../assets.json');
   server.use(morgan('combined'));
-  server.use('/build/static', express.static('./build/static'));
+  server.use('/static', express.static('./build/static'));
 }
 
 // Render Document (include global styles)
@@ -301,8 +301,8 @@ const renderFullPage = (data, initialState, assets) => {
         <div id="root">${data.html}</div>
         <script>window.renderedClassNames = ${JSON.stringify(data.css.renderedClassNames)};</script>
         <script>window.INITIAL_STATE = ${JSON.stringify(initialState)};</script>
-        <script src="${ isDeveloping ? '/build/static/vendor.js' : assets.vendor.js}"></script>
-        <script src="${ isDeveloping ? '/build/static/main.js' : assets.main.js}"></script>
+        <script src="${ isDeveloping ? '/static/vendor.js' : assets.vendor.js}"></script>
+        <script src="${ isDeveloping ? '/static/main.js' : assets.main.js}" async></script>
       </body>
     </html>
   `;

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -1,3 +1,4 @@
+import '../src/server/node-hooks'
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../src/server/server';

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -3,6 +3,10 @@ var path = require('path');
 var webpack = require('webpack');
 var AssetsPlugin = require('assets-webpack-plugin');
 
+var getPath = function (dir) {
+  return path.join(__dirname, dir);
+};
+
 module.exports = {
   devtool: 'source-map',
   entry: {
@@ -21,7 +25,7 @@ module.exports = {
     ]
   },
   output: {
-    path: path.join(__dirname, 'dist'),
+    path: getPath('temp'),
     filename: '[name].js',
     chunkFilename: '[id].chunk.js',
     publicPath: '/static/'
@@ -39,19 +43,22 @@ module.exports = {
   module: {
     loaders: [
       {
+        test: /\.js$/,
+        loader: 'babel',
+        query: { presets: ['es2015', 'react', 'stage-0'] },
+        include: getPath('src')
+      },
+      {
         test: /\.(gif|jpe?g|png|ico)$/,
-        loader: 'url-loader?limit=1000',
-        include: path.join(__dirname, 'src')
+        loader: 'file',
+        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        include: getPath('src')
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
-        loader: 'url-loader?limit=1000',
-        include: path.join(__dirname, 'src')
-      },
-      {
-        test: /\.js$/,
-        loaders: ['babel'],
-        include: path.join(__dirname, 'src')
+        loader: 'url',
+        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        include: getPath('src')
       },
     ]
   }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -26,7 +26,7 @@ module.exports = {
   output: {
     path: getPath('temp'),
     filename: '[name].js',
-    chunkFilename: '[id].chunk.js',
+    chunkFilename: '[id].[name].js',
     publicPath: '/static/'
   },
   plugins: [
@@ -53,13 +53,13 @@ module.exports = {
       {
         test: /\.(gif|jpe?g|png|ico)$/,
         loader: 'file',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        query: { limit: 10000, name: '[name].[hash].[ext]' },
         include: getPath('src')
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        query: { limit: 10000, name: '[name].[hash].[ext]' },
         include: getPath('src')
       },
     ]

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -45,7 +45,10 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel',
-        query: { presets: ['es2015', 'react', 'stage-0'] },
+        query: {
+          cacheDirectory: true,
+          presets: ['es2015', 'react', 'stage-0']
+        },
         include: getPath('src')
       },
       {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -46,7 +46,8 @@ module.exports = {
         loader: 'babel',
         query: {
           cacheDirectory: true,
-          presets: ['es2015', 'react', 'stage-0']
+          presets: ['es2015', 'react', 'stage-0'],
+          plugins: ['transform-runtime']
         },
         include: getPath('src')
       },

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,14 +1,13 @@
 // jscs:disable
-var path = require('path');
-var webpack = require('webpack');
-var AssetsPlugin = require('assets-webpack-plugin');
+var path = require('path')
+var webpack = require('webpack')
 
-var getPath = function (dir) {
-  return path.join(__dirname, dir);
-};
+var getPath = function getPath (dir) {
+  return path.join(__dirname, dir)
+}
 
 module.exports = {
-  devtool: 'source-map',
+  devtool: 'cheap-module-eval-source-map',
   entry: {
     main: [
       'webpack/hot/only-dev-server',
@@ -65,4 +64,4 @@ module.exports = {
       },
     ]
   }
-};
+}

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -24,7 +24,7 @@ module.exports = {
     path: path.join(__dirname, 'dist'),
     filename: '[name].js',
     chunkFilename: '[id].chunk.js',
-    publicPath: '/build/static/'
+    publicPath: '/static/'
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -3,7 +3,7 @@ var path = require('path')
 var webpack = require('webpack')
 var AssetsPlugin = require('assets-webpack-plugin')
 
-var getPath = function (dir) {
+var getPath = function getPath (dir) {
   return path.join(__dirname, dir)
 }
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -20,7 +20,7 @@ module.exports = {
      path: __dirname + '/build/static',
      filename: '[name]_[hash].js',
      chunkFilename: '[id].chunk_[hash].js',
-     publicPath: '/build/static/'
+    publicPath: '/static/'
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -8,7 +8,7 @@ var getPath = function getPath (dir) {
 }
 
 module.exports = {
-  devtool: false,
+  devtool: 'source-map',
   entry:  {
     main: ['./src/client.js'],
     vendor: [
@@ -22,13 +22,13 @@ module.exports = {
   },
   output: {
     path: getPath('/build/static'),
-    filename: '[name]_[hash].js',
-    chunkFilename: '[id].chunk_[hash].js',
+    filename: '[id].[name].[hash].js',
+    chunkFilename: '[id].[name].[chunkhash].js',
     publicPath: '/static/'
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
-    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor_[hash].js',  2),
+    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.[hash].js',  2),
     new webpack.optimize.DedupePlugin(),
     new AssetsPlugin({ filename: 'assets.json' }),
     new webpack.optimize.UglifyJsPlugin({
@@ -62,13 +62,13 @@ module.exports = {
       {
         test: /\.(gif|jpe?g|png|ico)$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        query: { limit: 10000, name: '[name].[hash].[ext]' },
         include: getPath('src')
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        query: { limit: 10000, name: '[name].[hash].[ext]' },
         include: getPath('src')
       }
     ]

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -53,6 +53,7 @@ module.exports = {
         query: {
           presets: ['es2015', 'react', 'stage-0'],
           plugins: [
+            'transform-runtime',
             'transform-react-constant-elements',
             'transform-react-inline-elements'
           ]

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,7 +1,11 @@
 // jscs:disable
-var path = require('path');
-var webpack = require('webpack');
-var AssetsPlugin = require('assets-webpack-plugin');
+var path = require('path')
+var webpack = require('webpack')
+var AssetsPlugin = require('assets-webpack-plugin')
+
+var getPath = function (dir) {
+  return path.join(__dirname, dir)
+}
 
 module.exports = {
   devtool: false,
@@ -17,16 +21,16 @@ module.exports = {
     ]
   },
   output: {
-     path: __dirname + '/build/static',
-     filename: '[name]_[hash].js',
-     chunkFilename: '[id].chunk_[hash].js',
+    path: getPath('/build/static'),
+    filename: '[name]_[hash].js',
+    chunkFilename: '[id].chunk_[hash].js',
     publicPath: '/static/'
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor_[hash].js',  2),
     new webpack.optimize.DedupePlugin(),
-    new AssetsPlugin({filename: 'assets.json'}),
+    new AssetsPlugin({ filename: 'assets.json' }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         unused: true,
@@ -45,16 +49,28 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel-loader?presets[]=es2015&presets[]=react&presets[]=stage-0',
-        include: path.join(__dirname, 'src')
-      },{
+        loader: 'babel',
+        query: {
+          presets: ['es2015', 'react', 'stage-0'],
+          plugins: [
+            'transform-react-constant-elements',
+            'transform-react-inline-elements'
+          ]
+        },
+        include: getPath('src')
+      },
+      {
         test: /\.(gif|jpe?g|png|ico)$/,
-        loader: 'url-loader?limit=10000'
+        loader: 'url',
+        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        include: getPath('src')
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
-        loader: 'url-loader?limit=10000'
+        loader: 'url',
+        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        include: getPath('src')
       }
     ]
   }
-};
+}

--- a/webpack.server.config.prod.js
+++ b/webpack.server.config.prod.js
@@ -3,11 +3,15 @@ var webpack = require('webpack')
 var fs =  require('fs')
 var path = require('path')
 
-function getExternals () {
-  var nodeModules = fs.readdirSync(path.resolve(__dirname, 'node_modules'))
-  return nodeModules.reduce(function (ext, mod) {
-    ext[mod] = 'commonjs ' + mod
-    return ext
+var getPath = function getPath (dir) {
+  return path.join(__dirname, dir)
+}
+
+var getExternals = function getExternals () {
+  var nodeModules = fs.readdirSync(path.resolve(getPath('node_modules')))
+  return nodeModules.reduce(function (mapExternals, mod) {
+    mapExternals[mod] = 'commonjs ' + mod
+    return mapExternals
   }, {})
 }
 
@@ -30,28 +34,31 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel',
-        include: path.join(__dirname, 'src'),
-        query: { presets: ['es2015', 'react', 'stage-0'] }
+        query: { presets: ['es2015', 'react', 'stage-0'] },
+        include: getPath('src'),
       },
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: 'json',
+        include: getPath('src')
       },
       {
         test: /\.(gif|jpe?g|png|ico)$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' }
+        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        include: getPath('src')
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' }
+        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        include: getPath('src')
       }
     ]
   },
   plugins: [
     new webpack.BannerPlugin(
-      'require("source-map-support").install()',
+      'require("source-map-support").install();',
       { raw: true, entryOnly: false }
     ),
     new webpack.optimize.UglifyJsPlugin({

--- a/webpack.server.config.prod.js
+++ b/webpack.server.config.prod.js
@@ -40,7 +40,6 @@ module.exports = {
       {
         test: /\.json$/,
         loader: 'json',
-        include: getPath('src')
       },
       {
         test: /\.(gif|jpe?g|png|ico)$/,

--- a/webpack.server.config.prod.js
+++ b/webpack.server.config.prod.js
@@ -1,14 +1,14 @@
 // jscs:disable
-var webpack = require('webpack');
-var fs =  require('fs');
-var path = require('path');
+var webpack = require('webpack')
+var fs =  require('fs')
+var path = require('path')
 
-function getExternals() {
-  const nodeModules = fs.readdirSync(path.resolve(__dirname, 'node_modules'));
+function getExternals () {
+  var nodeModules = fs.readdirSync(path.resolve(__dirname, 'node_modules'))
   return nodeModules.reduce(function (ext, mod) {
-    ext[mod] = 'commonjs ' + mod;
-    return ext;
-  }, {});
+    ext[mod] = 'commonjs ' + mod
+    return ext
+  }, {})
 }
 
 module.exports = {
@@ -16,8 +16,9 @@ module.exports = {
   devtool: 'inline-source-map',
   entry: './src/server/server.js',
   output: {
-    path: __dirname + '/build/server',
-    filename: 'index.js'
+    path: path.join(__dirname, '/build/server'),
+    filename: 'index.js',
+    publicPath: '/static/'
   },
   externals: getExternals(),
   node: {
@@ -25,28 +26,33 @@ module.exports = {
     __dirname: true
   },
   module: {
-    loaders: [{
+    loaders: [
+      {
         test: /\.js$/,
-        loader: 'babel-loader?presets[]=es2015&presets[]=react&presets[]=stage-0',
-        include: path.join(__dirname, 'src')
-      }, {
+        loader: 'babel',
+        include: path.join(__dirname, 'src'),
+        query: { presets: ['es2015', 'react', 'stage-0'] }
+      },
+      {
         test: /\.json$/,
-        loader: 'json-loader'
+        loader: 'json'
       },
       {
         test: /\.(gif|jpe?g|png|ico)$/,
-        loader: 'url-loader?limit=10000'
+        loader: 'url',
+        query: { limit: 10000, name: '[name].[ext]?[hash]' }
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
-        loader: 'url-loader?limit=10000'
+        loader: 'url',
+        query: { limit: 10000, name: '[name].[ext]?[hash]' }
       }
     ]
   },
   plugins: [
     new webpack.BannerPlugin(
-        'require("source-map-support").install();',
-        { raw: true, entryOnly: false }
+      'require("source-map-support").install()',
+      { raw: true, entryOnly: false }
     ),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
@@ -54,4 +60,4 @@ module.exports = {
       }
     })
   ]
-};
+}

--- a/webpack.server.config.prod.js
+++ b/webpack.server.config.prod.js
@@ -20,8 +20,9 @@ module.exports = {
   devtool: 'inline-source-map',
   entry: './src/server/server.js',
   output: {
-    path: path.join(__dirname, '/build/server'),
+    path: getPath('/build/server'),
     filename: 'index.js',
+    chunkFilename: '[id].[name].[chunkhash].js',
     publicPath: '/static/'
   },
   externals: getExternals(),
@@ -44,13 +45,13 @@ module.exports = {
       {
         test: /\.(gif|jpe?g|png|ico)$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        query: { limit: 10000, name: '[name].[hash].[ext]' },
         include: getPath('src')
       },
       {
         test: /\.(otf|eot|svg|ttf|woff|woff2).*$/,
         loader: 'url',
-        query: { limit: 10000, name: '[name].[ext]?[hash]' },
+        query: { limit: 10000, name: '[name].[hash].[ext]' },
         include: getPath('src')
       }
     ]


### PR DESCRIPTION
summary...
- added [node-hooks for resolving files in node](https://github.com/justingreenberg/react-production-starter/blob/351d83a596d70218a2ecda4615393fc9ba784d69/src/server/node-hooks.js)
- updated file/url loaders to use filenames and content hash for caching
- fixed some inconsistent styling, ie using es5 in webpack entry files for older runtimes 
- update configs to use loader query objects instead of query string syntax
- added simple `getPath` helper to webpack configs for relative path resolution
- moved react optimizations from root `.babelrc` into prod webpack config... maybe consider removing babelrc altogether?
- remove unnecessary `/build` path from public URI, [just use `/static` instead](https://github.com/jaredpalmer/react-production-starter/compare/images...justingreenberg:images?expand=1#diff-f286c15f5cb962ed226f2aae653ca1cfR88)
- update script tag for [main.js with `async` attribute](https://github.com/jaredpalmer/react-production-starter/compare/images...justingreenberg:images?expand=1#diff-f286c15f5cb962ed226f2aae653ca1cfR305) since vendor has entry logic

i wasn't able to workaround the duplicate file output to `build/server`, imo not a huge problem but something that we can create a ticket for and i will investigate further

let me know if you have any questions :)

edit: tests passed by importing node-hooks into server test file, which is a good sign