### PR TITLE
Fix HMR memory leak in client

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -14,13 +14,15 @@ const initialState = window.INITIAL_STATE || {}
 // Set up Redux (note: this API requires redux@>=3.1.0):
 const store = configureStore(initialState)
 const { dispatch } = store
-const { pathname, search, hash } = window.location
-const location = `${pathname}${search}${hash}`
+
 const container = document.getElementById('root')
 
 StyleSheet.rehydrate(window.renderedClassNames)
 
-let render = () => {
+const render = () => {
+  const { pathname, search, hash } = window.location
+  const location = `${pathname}${search}${hash}`
+
   // We need to have a root route for HMR to work.
   const createRoutes = require('../common/routes/root').default
   const routes = createRoutes(store)
@@ -39,7 +41,7 @@ let render = () => {
     )
   })
 
-  browserHistory.listen(location => {
+  return browserHistory.listen(location => {
     // Match routes based on location object:
     match({ routes, location }, (error, redirectLocation, renderProps) => {
       if (error) console.log(error)
@@ -71,10 +73,11 @@ let render = () => {
   })
 }
 
+const unsubscribeHistory = render()
+
 if (module.hot) {
   module.hot.accept('../common/routes/root', () => {
+    unsubscribeHistory()
     setTimeout(render)
   })
 }
-
-render()


### PR DESCRIPTION
- moves location variable into render function scope as name conflicts with param return by history.listen
- prevents binding duplicate event listeners to history by unsubscribing before hot reload 

this could also be fixed by adding a dispose handler to module.hot and passing reference to subscription, but this solution seems easier to grok without deep understanding of webpack api