### PR TITLE
Enable .babelrc plugins only in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,8 @@
 {
   "presets": ["es2015", "react", "stage-0"],
-  "plugins": ["transform-react-constant-elements", "transform-react-inline-elements"]
+  "env": {
+      "production": {
+          "plugins": ["transform-react-constant-elements", "transform-react-inline-elements"]
+      }
+  }
 }


### PR DESCRIPTION
"transform-react-constant-elements" and "transform-react-inline-elements" must not run in development environment

> This transform should be enabled only in production (e.g., just before minifying your code) because although it improves runtime performance, it makes warning messages more cryptic.
https://babeljs.io/docs/plugins/transform-react-inline-elements/
https://babeljs.io/docs/plugins/transform-react-constant-elements/