### PR TITLE
Provide query to server-side fetch hook

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -67,7 +67,7 @@ server.get('*', (req, res) => {
     }
   })
   const routes = createRoutes(store)
-  const history = createMemoryHistory(req.path)
+  const history = createMemoryHistory(req.originalUrl)
   const { dispatch } = store
 
   match({ routes, history}, (err, redirectLocation, renderProps) => {
@@ -85,7 +85,7 @@ server.get('*', (req, res) => {
     // Define locals to be provided to all lifecycle hooks:
     const locals = {
       path: renderProps.location.pathname,
-      query: req.query,
+      query: renderProps.location.query,
       params: renderProps.params,
 
       // Allow lifecycle hooks to dispatch Redux actions:

--- a/server/server.js
+++ b/server/server.js
@@ -85,7 +85,7 @@ server.get('*', (req, res) => {
     // Define locals to be provided to all lifecycle hooks:
     const locals = {
       path: renderProps.location.pathname,
-      query: renderProps.location.query,
+      query: req.query,
       params: renderProps.params,
 
       // Allow lifecycle hooks to dispatch Redux actions:


### PR DESCRIPTION
If you'd want to access query e.g. [here](https://github.com/jaredpalmer/react-production-starter/blob/master/common/routes/PostList/containers/PostList.js#L11), it is undefined. Therefore if you enter `http://localhost:5000/posts?a=1` directly (not by routing to it from a different page), `renderProps.location` has no `query` property. Client-side works fine.