### PR TITLE
fix: Escape inline start script for PowerShell

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "cross-env NODE_ENV=test ./node_modules/mocha/bin/mocha --compilers js:babel-core/register --recursive",
     "test:watch": "npm test -- --watch",
     "coverage": "nyc npm test",
-    "start": "cross-env NODE_ENV=development node -r 'babel-register' ./server",
+    "start": "cross-env NODE_ENV=development node -r \"babel-register\" ./server",
     "start:prod": "cross-env NODE_ENV=production node ./build/server.js",
     "heroku-postbuild": "npm run build",
     "build": "webpack -p --config ./tools/webpack.client.prod.js && webpack -p --config ./tools/webpack.server.prod.js",


### PR DESCRIPTION
Single quotes inside the NPM start script throws the following error when running "npm start" from Windows PowerShell:

``` Error: Cannot find module ''babel-register'' ```

(note the duplicated single quotes)
Replacing the single quotes with escaped double quotes allows starting the application from PowerShell.