### PR TITLE
Fix #172

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^15.2.1",
     "react-helmet": "^3.1.0",
     "react-redux": "^4.4.0",
-    "react-router": "^3.0.0",
+    "react-router": "^2.0.0",
     "redial": "^0.4.1",
     "redux": "^3.3.1",
     "redux-thunk": "^2.1.0",


### PR DESCRIPTION
This rollsback the bump up to react-router v3, which messed up lazy-loading on the client. More investigation needed.